### PR TITLE
Add pagination to blog index (Issue #126)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,11 @@ footer-links:
   youtube: # channel/<your_long_string> or user/<user-name>
   googleplus: "+PhotoVisionPrints"
 
+# Number of items to show per page when paginating
+paginate: 5
+
+# Destination of the pagination pages
+paginate_path: "/blog/page:num/"
 
 # Enter your Disqus shortname (not your username) to enable commenting on posts
 # You can find your shortname on the Settings page of your Disqus account
@@ -94,6 +99,7 @@ plugins:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
   - jemoji # GitHub-flavored Emoji plugin for Jekyll
+  - jekyll-paginate # Jekyll pagination plugin
 
 # Exclude these files from your production _site
 exclude:

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="posts">
-  {% for post in site.posts %}
+  {% for post in paginator.posts %}
     <article class="post">
 
       <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
@@ -16,4 +16,15 @@ layout: default
       
     </article>
   {% endfor %}
+
+  <!-- Pagination links -->
+  <div class="center pagination">
+    {% if paginator.previous_page %}
+      <a href="{{ paginator.previous_page_path }}" class="previous left">Previous</a>
+    {% endif %}
+    {% if paginator.next_page %}
+      <a href="{{ paginator.next_page_path }}" class="next right">Next</a>
+    {% endif %}
+  </div>
+  <div class="clearfix"></div>
 </div>

--- a/style.scss
+++ b/style.scss
@@ -898,8 +898,21 @@ article {
   }
 }
 
-.posts .heading {  
-  padding: 0% 10%;
+.posts {
+  .heading {  
+    padding: 0% 10%;
+  }
+  .pagination {
+    width: 50%;
+    .previous:before {
+      font-family: Webdings;
+      content: "3 ";
+    }
+    .next:after {
+      font-family: Webdings;
+      content: " 4";
+    }
+  }
 }
 
 .post {


### PR DESCRIPTION
Pagination now works, but only on the page that displays all posts.
Pagination for posts by category is not yet supported on GitHub Pages
sites built with Jekyll.